### PR TITLE
[proposal] feat: introduces new `parentIndex` and `faceIndex` in Sp3dFaceObj

### DIFF
--- a/lib/src/sp3d_camera.dart
+++ b/lib/src/sp3d_camera.dart
@@ -124,7 +124,8 @@ class Sp3dCamera {
   /// Returns calculated data.
   List<Sp3dFaceObj> getPrams(List<Sp3dObj> objs, Sp3dV2D origin) {
     List<Sp3dFaceObj> r = [];
-    for (Sp3dObj obj in objs) {
+    for (var i = 0; i < objs.length; i++) {
+      final Sp3dObj obj = objs[i];
       final List<Sp3dV2D> conv2d = convert(obj, origin);
       if (obj.drawMode == EnumSp3dDrawMode.rect) {
         // 長方形に近似した結果をFaceとして返す。
@@ -148,6 +149,7 @@ class Sp3dCamera {
         }
         r.add(Sp3dFaceObj(
             obj,
+            i,
             obj.fragments[0],
             0,
             obj.fragments[0].faces[0],
@@ -163,10 +165,10 @@ class Sp3dCamera {
             1,
             100));
       } else {
-        for (var i = 0; i < obj.fragments.length; i++) {
-          final Sp3dFragment fragment = obj.fragments[i];
-          for (var j = 0; j < fragment.faces.length; j++) {
-            final Sp3dFace face = fragment.faces[j];
+        for (var j = 0; j < obj.fragments.length; j++) {
+          final Sp3dFragment fragment = obj.fragments[j];
+          for (var k = 0; k < fragment.faces.length; k++) {
+            final Sp3dFace face = fragment.faces[k];
             final List<Sp3dV3D> v = face.getVertices(obj);
             final Sp3dV3D n = Sp3dV3D.surfaceNormal(v).nor();
             final Sp3dV3D c = Sp3dV3D.ave(v);
@@ -176,12 +178,12 @@ class Sp3dCamera {
             final double dist = Sp3dV3D.dist(c, rotatedPosition);
             if (isAllDrawn) {
               r.add(Sp3dFaceObj(
-                  obj, fragment, i, face, j, v, v2dl, n, camTheta, dist));
+                  obj, i, fragment, j, face, k, v, v2dl, n, camTheta, dist));
             } else {
               // cosΘがマイナスなら、カメラの向きと面の向きが同じなので描画対象外
               if (camTheta >= 0) {
                 r.add(Sp3dFaceObj(
-                    obj, fragment, i, face, j, v, v2dl, n, camTheta, dist));
+                    obj, i, fragment, j, face, k, v, v2dl, n, camTheta, dist));
               }
             }
           }

--- a/lib/src/sp3d_camera.dart
+++ b/lib/src/sp3d_camera.dart
@@ -149,7 +149,9 @@ class Sp3dCamera {
         r.add(Sp3dFaceObj(
             obj,
             obj.fragments[0],
+            0,
             obj.fragments[0].faces[0],
+            0,
             obj.vertices,
             [
               Sp3dV2D(minX, minY),
@@ -161,21 +163,25 @@ class Sp3dCamera {
             1,
             100));
       } else {
-        for (Sp3dFragment i in obj.fragments) {
-          for (Sp3dFace j in i.faces) {
-            final List<Sp3dV3D> v = j.getVertices(obj);
+        for (var i = 0; i < obj.fragments.length; i++) {
+          final Sp3dFragment fragment = obj.fragments[i];
+          for (var j = 0; j < fragment.faces.length; j++) {
+            final Sp3dFace face = fragment.faces[j];
+            final List<Sp3dV3D> v = face.getVertices(obj);
             final Sp3dV3D n = Sp3dV3D.surfaceNormal(v).nor();
             final Sp3dV3D c = Sp3dV3D.ave(v);
             // ここでは回転後の値を使う。
             final double camTheta = Sp3dV3D.dot(n, (c - rotatedPosition).nor());
-            final List<Sp3dV2D> v2dl = _get2dV(j, conv2d);
+            final List<Sp3dV2D> v2dl = _get2dV(face, conv2d);
             final double dist = Sp3dV3D.dist(c, rotatedPosition);
             if (isAllDrawn) {
-              r.add(Sp3dFaceObj(obj, i, j, v, v2dl, n, camTheta, dist));
+              r.add(Sp3dFaceObj(
+                  obj, fragment, i, face, j, v, v2dl, n, camTheta, dist));
             } else {
               // cosΘがマイナスなら、カメラの向きと面の向きが同じなので描画対象外
               if (camTheta >= 0) {
-                r.add(Sp3dFaceObj(obj, i, j, v, v2dl, n, camTheta, dist));
+                r.add(Sp3dFaceObj(
+                    obj, fragment, i, face, j, v, v2dl, n, camTheta, dist));
               }
             }
           }

--- a/lib/src/sp3d_faceobj.dart
+++ b/lib/src/sp3d_faceobj.dart
@@ -13,6 +13,8 @@ import 'sp3d_v2d.dart';
 class Sp3dFaceObj {
   // The object to which this face belongs.
   final Sp3dObj obj;
+  // The object index in the list.
+  final int objIndex;
   // This face parent.
   final Sp3dFragment parent;
   // The index of the parent in the obj fragments list.
@@ -34,6 +36,7 @@ class Sp3dFaceObj {
 
   Sp3dFaceObj(
     this.obj,
+    this.objIndex,
     this.parent,
     this.parentIndex,
     this.face,

--- a/lib/src/sp3d_faceobj.dart
+++ b/lib/src/sp3d_faceobj.dart
@@ -15,8 +15,12 @@ class Sp3dFaceObj {
   final Sp3dObj obj;
   // This face parent.
   final Sp3dFragment parent;
+  // The index of the parent in the obj fragments list.
+  final int parentIndex;
   // This face obj.
   final Sp3dFace face;
+  // The index of the face in the fragment faces list.
+  final int faceIndex;
   // Face vertices in the world.
   final List<Sp3dV3D> vertices3d;
   // Face vertices on display.
@@ -28,6 +32,16 @@ class Sp3dFaceObj {
   // Distance between the average position of this surface and the camera.
   final double dist;
 
-  Sp3dFaceObj(this.obj, this.parent, this.face, this.vertices3d,
-      this.vertices2d, this.nsn, this.camTheta, this.dist);
+  Sp3dFaceObj(
+    this.obj,
+    this.parent,
+    this.parentIndex,
+    this.face,
+    this.faceIndex,
+    this.vertices3d,
+    this.vertices2d,
+    this.nsn,
+    this.camTheta,
+    this.dist,
+  );
 }


### PR DESCRIPTION
Good afternoon,

First, thank you so much for this package, it works awesomely well and it is exactly what i needed.

I am opening this PR to suggest to includes both `parentIndex` (fragmentIndex) and `faceIndex` in Sp3dFaceObj.

It is needed for my use case, where i want to know exactly where my cube was touched (each fragments faces represents a different option). I am using it as such :

```dart
Sp3dRenderer(
  widget.size,
  Sp3dV2D(widget.size.width / 2, widget.size.height / 2),
  _world,
  _camera,
  _light,
  pinchZoomSpeed: 4,
  vn: _vn,
  onPanDown: (Sp3dGestureDetails details, Sp3dFaceObj? obj) {
    if (obj == null) {
      return;
    }
    _isCubePanned = true;

    const List<List<int>> _kCubeIndexesMap = [
      [0, 1, 2, 3], // faceIndex 0 front
      [5, 4, 7, 6], // faceIndex 1 back
      [2, 3, 6, 7], // faceIndex 2 top
      [4, 0, 6, 2], // faceIndex 3 left
      [4, 5, 0, 1], // faceIndex 4 bottom
      [1, 5, 3, 7], // faceIndex 5 right
    ];

    final index =
        _kCubeIndexesMap[obj.faceIndex].indexOf(obj.parentIndex);
    if (index == -1) return null;

    // here i apply my tap logic based on the index and obj.faceIndex
  },
  onPanUpdate: (Sp3dGestureDetails details) {
    if (_isCubePanned) {
      // rotate manually if object is touched
      _rCtrl.apply(_camera, details);
      // rerender
      _vn.value += 1;
    }
  },
  onPanEnd: (_) => _isCubePanned = false,
  rotationController: _rCtrl,
);
```